### PR TITLE
 商品一覧表示機能 #6

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   def index
-    @items = Item.all
+    @items = Item.order(created_at: :desc)
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,7 +131,7 @@
       <% if @items.any? %>
        <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to item_path(item) do %>
+        <%= link_to "#" do %>
         <div class='item-img-content'>
           <%= image_tag item.image.variant(resize: '500x500'), class: "item-img" %>
           <%# 商品が売れていればsold outを表示しましょう %>
@@ -159,8 +159,6 @@
       </li>
       <% end %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
       <% else %>
       <li class='list'>
         <%= link_to '#' do %>
@@ -179,8 +177,7 @@
         </div>
       </li>
         <% end %>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+        
       <% end %>
     </ul>
   </div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,25 +128,27 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% if @items.any? %>
+       <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item) do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
-
+          <%= image_tag item.image.variant(resize: '500x500'), class: "item-img" %>
           <%# 商品が売れていればsold outを表示しましょう %>
-          <div class='sold-out'>
+          <%# if item.sold_out? %>
+         <%# <div class='sold-out'>
             <span>Sold Out!!</span>
-          </div>
+          </div> %>
+          <%# end %>
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.item_name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.ship_cost.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -155,10 +157,11 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% end %>
 
       <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
       <%# 商品がある場合は表示されないようにしましょう %>
+      <% else %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -174,10 +177,11 @@
             </div>
           </div>
         </div>
-        <% end %>
       </li>
+        <% end %>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+      <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>


### PR DESCRIPTION
**What**
商品一覧表示機能を実装しました。

**Why**
出品された商品をトップページに一覧で表示することで、ユーザーが商品を閲覧・購入しやすくするため。

**Gyazo（機能確認用動画）**
[商品が出品されていない場合、ダミー商品が表示される動画](https://gyazo.com/03cd492b1731874e028708b07254286b)


[商品が出品されている場合、一覧で表示されている動画（2つ以上の商品がある状態）](https://gyazo.com/4b280492b33dc7cfc07e7a6e62f09afd)