### PR TITLE
商品詳細表示機能 #7

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -16,6 +16,11 @@ class ItemsController < ApplicationController
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+    @user = @item.user
+  end
+
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,5 @@
 class ItemsController < ApplicationController
+  before_action :authenticate_user!, except: [:index, :show]
   def index
     @items = Item.order(created_at: :desc)
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -28,7 +28,7 @@ class Item < ApplicationRecord
   validates :category_id, :condition_id, :ship_cost_id, :prefecture_id, :delivery_time_id,
             numericality: { other_than: 1, message: "can't be blank" }
 
-  def sold_out?
-    false
-  end
+  # def sold_out?
+  # false
+  # end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -27,4 +27,8 @@ class Item < ApplicationRecord
                                     less_than_or_equal_to: 9_999_999 }
   validates :category_id, :condition_id, :ship_cost_id, :prefecture_id, :delivery_time_id,
             numericality: { other_than: 1, message: "can't be blank" }
+
+  def sold_out?
+    false
+  end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,7 +131,7 @@
       <% if @items.any? %>
        <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item) do %>
         <div class='item-img-content'>
           <%= image_tag item.image.variant(resize: '500x500'), class: "item-img" %>
           <%# 商品が売れていればsold outを表示しましょう %>
@@ -177,7 +177,7 @@
         </div>
       </li>
         <% end %>
-        
+
       <% end %>
     </ul>
   </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,11 +8,11 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image ,class:"item-box-img" %>
-      <% if @item.sold_out? %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
-      </div>
-      <% end %>
+      <%# if @item.sold_out? %>
+      <%#< div class="sold-out"> %>
+       <%# <span>Sold Out!!</span>%>
+     <%# </div>%>
+      <%# end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -23,15 +23,15 @@
       </span>
     </div>
 
-    <% if user_signed_in? && current_user == @item.user && !@item.sold_out? %>
+    <% if user_signed_in? %>
+    <% if current_user == @item.user %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
-    <% end %>
-
-    <% if user_signed_in? && current_user != @item.user && !@item.sold_out? %>
+    <% else %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%end%>
+    <% end %>
+    <% end %>
 
     <div class="item-explain-box">
       <span><%= @item.item_name %></span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,7 +8,6 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
       <% if @item.sold_out? %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -24,20 +23,15 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
     <% if user_signed_in? && current_user == @item.user && !@item.sold_out? %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
     <% end %>
 
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
     <% if user_signed_in? && current_user != @item.user && !@item.sold_out? %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
     <%end%>
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= @item.item_name %></span>
@@ -105,9 +99,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,67 +4,69 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.item_name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
+      <% if @item.sold_out? %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <% end %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+       ¥ <%= @item.price%> 
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.ship_cost.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+    <% if user_signed_in? && current_user == @item.user && !@item.sold_out? %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
-
+    <% end %>
 
     <%# 商品が売れていない場合はこちらを表示しましょう %>
+    <% if user_signed_in? && current_user != @item.user && !@item.sold_out? %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-
+    <%end%>
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.item_name %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.ship_cost.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.delivery_time.name %></td>
         </tr>
       </tbody>
     </table>


### PR DESCRIPTION
**What**

商品詳細表示機能を実装しました。

⸻

**Why**

ユーザーが出品された商品の詳細情報を確認できるようにするため。また、ログイン状態や出品者との関係に応じて、表示されるボタンを適切に制御するためです。

⸻

**Gyazo（機能確認用動画）**
	1.	[ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画](https://gyazo.com/58fcf64744e277560e62429b106969b2)
	2.	[ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画](https://gyazo.com/e0712aecb9b82c506ad35e76a68f4942)
	3.	[ログアウト状態で、商品詳細ページへ遷移した動画](https://gyazo.com/8a81a3ff1e716968fad0ea0f8ccb6e7a)**