### PR TITLE
商品削除機能 #9の実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index, :show]
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
   def index
     @items = Item.order(created_at: :desc)
   end
@@ -15,6 +15,15 @@ class ItemsController < ApplicationController
       redirect_to root_path
     else
       render :new, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    if current_user.id == @item.user_id
+      @item.destroy
+      redirect_to root_path
+    else
+      redirect_to root_path, alert: '削除権限がありません。'
     end
   end
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,9 +27,9 @@
     <% if current_user == @item.user %>
     <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
-    <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+    <%= link_to "削除", item_path(@item), data: {turbo_method: :delete}, class:"item-destroy" %>
     <% else %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+    <%= link_to "購入画面に進む", "" ,class:"item-red-btn"%>
     <% end %>
     <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
 root to: 'items#index'
 resources :users, only: [:edit, :update]
-resources :items, only: [:new, :create, :edit, :destroy, :show, :index, :update]
+resources :items
 end


### PR DESCRIPTION
**What**

商品削除機能を実装しました。ログイン中の出品者のみが商品詳細ページから出品商品を削除できるようにし、削除後はトップページへ遷移する仕様です。

**Why**

ユーザーが出品した商品の管理を行えるようにするため。また、本人以外が削除できないように制御し、アプリの安全性と正当性を保つためです。

 **動作確認用Gyazoリンク：**
	1.	[ログイン状態の出品者のみ、詳細ページの削除ボタンを押すと、出品した商品を削除できる動画](https://gyazo.com/18ed31dc42606cdd0da1ed4cc265198d)